### PR TITLE
Ensure fullscreen map and layer toggle

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
-	import favicon from '$lib/assets/favicon.svg';
+  import favicon from "$lib/assets/favicon.svg";
 
-	let { children } = $props();
+  let { children } = $props();
 </script>
 
 <svelte:head>
-	<link rel="icon" href={favicon} />
+  <link rel="icon" href={favicon} />
 </svelte:head>
 
 {@render children?.()}
+
+<style>
+  :global(html, body) {
+    height: 100%;
+    margin: 0;
+    overflow: hidden;
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,89 +1,105 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import maplibregl from 'maplibre-gl';
+  import { onMount } from "svelte";
+  import maplibregl from "maplibre-gl";
+  import "maplibre-gl/dist/maplibre-gl.css";
 
-	let map: maplibregl.Map;
-	let showParcele = true;
+  let map: maplibregl.Map;
+  let showParcele = true;
 
-	onMount(() => {
-		navigator.geolocation.getCurrentPosition((pos) => {
-			const { latitude, longitude } = pos.coords;
+  onMount(() => {
+    navigator.geolocation.getCurrentPosition((pos) => {
+      const { latitude, longitude } = pos.coords;
 
-			map = new maplibregl.Map({
-				container: 'map',
-				style: {
-					version: 8,
-					sources: {
-						basemap: {
-							type: 'raster',
-							tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
-							tileSize: 256
-						},
-						...(showParcele && {
-							parcele: {
-								type: 'vector',
-								tiles: ['http://localhost:8080/data/parcele/{z}/{x}/{y}.pbf'],
-								maxzoom: 22
-							}
-						})
-					},
-					layers: [
-						{
-							id: 'osm',
-							type: 'raster',
-							source: 'basemap'
-						},
-						...(showParcele
-							? [
-									{
-										id: 'parcele-fill',
-										type: 'fill',
-										source: 'parcele',
-										'source-layer': 'parcele', // ❗️Replace with your actual .mbtiles layer name
-										paint: {
-											'fill-color': '#088',
-											'fill-opacity': 0.4
-										}
-									}
-							  ]
-							: [])
-					]
-				},
-				center: [longitude, latitude],
-				zoom: 14
-			});
-		});
-	});
+      map = new maplibregl.Map({
+        container: "map",
+        style: {
+          version: 8,
+          sources: {
+            basemap: {
+              type: "raster",
+              tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+              tileSize: 256,
+            },
+            parcele: {
+              type: "vector",
+              tiles: ["http://localhost:8080/data/parcele/{z}/{x}/{y}.pbf"],
+              maxzoom: 22,
+            },
+          },
+          layers: [
+            {
+              id: "osm",
+              type: "raster",
+              source: "basemap",
+            },
+            {
+              id: "parcele-fill",
+              type: "fill",
+              source: "parcele",
+              "source-layer": "parcele", // ❗️Replace with your actual .mbtiles layer name
+              layout: {
+                visibility: showParcele ? "visible" : "none",
+              },
+              paint: {
+                "fill-color": "#088",
+                "fill-opacity": 0.4,
+              },
+            },
+          ],
+        },
+        center: [longitude, latitude],
+        zoom: 14,
+        attributionControl: false,
+        maplibreLogo: false,
+      });
 
-	function toggleParcele() {
-		showParcele = !showParcele;
-		location.reload(); // Simplest way to rebuild the map (for now)
-	}
+      map.on("load", () => {
+        map.setLayoutProperty(
+          "parcele-fill",
+          "visibility",
+          showParcele ? "visible" : "none",
+        );
+      });
+    });
+  });
+
+  function toggleParcele() {
+    showParcele = !showParcele;
+    map.setLayoutProperty(
+      "parcele-fill",
+      "visibility",
+      showParcele ? "visible" : "none",
+    );
+  }
 </script>
 
-<style>
-	#map {
-		width: 100vw;
-		height: 100vh;
-	}
-
-	.controls {
-		position: absolute;
-		top: 1rem;
-		left: 1rem;
-		z-index: 10;
-		background: white;
-		padding: 0.5rem 1rem;
-		border-radius: 0.5rem;
-		box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-	}
-</style>
-
 <div class="controls">
-	<label>
-		<input type="checkbox" bind:checked={showParcele} on:change={toggleParcele} />
-		Show Parcela Layer
-	</label>
+  <label>
+    <input
+      type="checkbox"
+      bind:checked={showParcele}
+      on:change={toggleParcele}
+    />
+    Show Parcela Layer
+  </label>
 </div>
 
 <div id="map"></div>
+
+<style>
+  #map {
+    position: fixed;
+    inset: 0;
+  }
+
+  .controls {
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
+    z-index: 10;
+    background: white;
+    padding: 0.5rem 1rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  }
+</style>


### PR DESCRIPTION
## Summary
- Remove page scrollbars and make the map fill the viewport
- Import MapLibre CSS and hide default controls
- Make "Show Parcela Layer" checkbox toggle parcel layer visibility

## Testing
- `pnpm lint` *(fails: Code style issues found in 8 files. Run Prettier with --write to fix.)*
- `pnpm check`
- `npx prettier --check src/routes/+layout.svelte src/routes/+page.svelte --plugin=prettier-plugin-svelte`


------
https://chatgpt.com/codex/tasks/task_e_68924bbe8c50832dbec7057761cc1476